### PR TITLE
Add a Psi4 lab

### DIFF
--- a/20_Psi4_Intro.ipynb
+++ b/20_Psi4_Intro.ipynb
@@ -1,0 +1,1410 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "# 0. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "pre {\n",
+    "    background-color: #f5f5f5;\n",
+    "}\n",
+    "foo <font color='red'>bar</font> foo\n",
+    "* Install a binary from conda (Linux or Mac) through instructions\n",
+    "http://psicode.org/psi4manual/master/conda.html#how-to-install-a-psi4-binary-with-the-psi4conda-installer-download-site\n",
+    "  * ``conda install jupyter matplotlib``\n",
+    "* Log into a remote machine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#! export PATH=/Users/loriab/linux/psihub/hrw-labfork/objdir4/stage/Users/loriab/linux/psihub/install-hrw-labfork/bin:$PATH\n",
+    "! export PATH=/Users/loriab/linux/psihub/hrw-labfork/objdir-dev36/stage/usr/local/psi4/bin:$PATH\n",
+    "! which psi4\n",
+    "! echo $PSIDATADIR\n",
+    "! echo $PYTHONPATH\n",
+    "! echo $PSI_SCRATCH"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! export PATH=/Users/loriab/linux/psihub/hrw-labfork/objdir-dev36/stage/usr/local/psi4/bin:$PATH\n",
+    "! echo $PATH\n",
+    "! which psi4\n",
+    "import os\n",
+    "# help(os.environ)\n",
+    "os.environ['PATH'] = '/Users/loriab/linux/psihub/hrw-labfork/objdir-dev36/stage/usr/local/psi4/bin:$PATH'\n",
+    "! which psi4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Psithon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile setup.in\n",
+    "molecule h2o {\n",
+    "  O \n",
+    "  H 1 0.96\n",
+    "  H 1 0.96 2 104.5\n",
+    "}\n",
+    "\n",
+    "set basis cc-pVDZ\n",
+    "energy('scf')\n",
+    "\n",
+    "compare_values(-76.0266327341067125, get_variable('SCF TOTAL ENERGY'), 6, 'SCF energy')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!psi4 setup.in"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### PsiAPI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "import psi4\n",
+    "psi4.set_memory(int(5e8))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "psi4.test()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": true
+    }
+   },
+   "source": [
+    "## I. Overview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "## A. Single-point application: the complete basis set (CBS) limit\n",
+    "\n",
+    "from lab by Eugene DePrince, FSU"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "### 0. Basis set limit\n",
+    "\n",
+    "**Q.** For a single hydrogen atom, set up a new Hartree–Fock job with a minimal basis set (STO-3G). Since H has one electron, we can't use a restricted (RHF) reference. Switch the reference to unrestricted (UHF), and make sure the multiplicity is a doublet and the charge is zero. Submit your job and view the output file. Scroll to the bottom to see the Hartree–Fock energy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "psi4.core.clean_variables()\n",
+    "psi4.core.clean_options()\n",
+    "psi4.core.clean()\n",
+    "\n",
+    "# cbs_0.in\n",
+    "psi4.set_output_file(\"cbs_0.out\", True)\n",
+    "\n",
+    "hatom = psi4.geometry(\"\"\"\n",
+    "0 2  # neutral atom, doublet multiplicity\n",
+    "H\n",
+    "\"\"\")\n",
+    "\n",
+    "psi4.set_options({'reference': 'uhf',\n",
+    "                  'basis': 'sto-3g'})\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#set basis sto-3g\n",
+    "#set basis 6-31g*\n",
+    "#set basis cc-pvDZ\n",
+    "#set basis cc-pvtZ\n",
+    "\n",
+    "ans = psi4.energy('scf')\n",
+    "psivars = psi4.core.get_variables()\n",
+    "\n",
+    "print ('H atom energy is', ans)\n",
+    "print(psi4.core.get_variables())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(psivars['ONE-ELECTRON ENERGY'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "! cat cbs_0.out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "number_basis_functions = []\n",
+    "hydrogen_atom_energy = []\n",
+    "\n",
+    "for bas in ['sto-3g', '6-31g*', 'cc-pvdz', 'cc-pVTZ']:\n",
+    "    \n",
+    "    psi4.core.clean_variables()\n",
+    "    #psi4.core.clean_options()\n",
+    "    psi4.core.clean()\n",
+    "\n",
+    "    psi4.set_options({'basis': bas})\n",
+    "    E, wfn = psi4.energy('scf', return_wfn=True)\n",
+    "    \n",
+    "    number_basis_functions.append(wfn.basisset().nbf())\n",
+    "    hydrogen_atom_energy.append(E)\n",
+    "\n",
+    "print(number_basis_functions)\n",
+    "print(hydrogen_atom_energy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": true
+    }
+   },
+   "source": [
+    "**Q.** Record the energy to 5 decimal places and include appropriate units. Record the number of basis functions (_not_ Cartesian basis functions) in the \"Primary Basis\" section. Repeat for basis sets 6-31G, cc-pVDZ, and cc-pVTZ. What value does the energy approach? Which basis set is most accurate? Why?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# number_basis_functions = [1, 2, 5, 14]\n",
+    "# hydrogen_atom_energy = [-0.4665818495572753, -0.49823291072907, -0.49927840341958, -0.4998098113018429]\n",
+    "\n",
+    "plt.plot(number_basis_functions, hydrogen_atom_energy, 'b-o')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "Now evaluate the complete basis set (CBS) energy according to this extrapolation formula:\n",
+    "\n",
+    "Helgaker's 2-point extrapolation\n",
+    "* $E_x = E_{\\text{CBS}} + \\beta e^{-\\alpha x}$\n",
+    "* $\\alpha=1.63$\n",
+    "* $E_x$ is energy computed in a given basis set\n",
+    "* $x$ is zeta level of that basis\n",
+    "* $\\beta$ and $E_{\\text{CBS}}$ are unknowns. Latter is target"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "### Method 1: by hand"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "psi4.core.clean_variables()\n",
+    "psi4.core.clean_options()\n",
+    "psi4.core.clean()\n",
+    "\n",
+    "psi4.set_output_file(\"cbs_1.out\", True)\n",
+    "\n",
+    "hatom = psi4.geometry(\"\"\"\n",
+    "0 2  # neutral atom, doublet multiplicity\n",
+    "H\n",
+    "\"\"\")\n",
+    "\n",
+    "psi4.set_options({'reference': 'uhf',\n",
+    "                  'basis': 'cc-pvdz'})\n",
+    "\n",
+    "eLO = psi4.energy('hf')\n",
+    "\n",
+    "print('eLO =', eLO)\n",
+    "\n",
+    "psi4.core.clean_variables()\n",
+    "psi4.core.clean_options()\n",
+    "psi4.core.clean()\n",
+    "\n",
+    "psi4.set_options({'reference': 'uhf',\n",
+    "                  'basis': 'cc-pvtz'})\n",
+    "\n",
+    "eHI = psi4.energy('hf')\n",
+    "\n",
+    "print('eHI =', eHI)\n",
+    "\n",
+    "\n",
+    "\n",
+    "# %%writefile cbs_1.in\n",
+    "# molecule hatom {\n",
+    "# 0 2  # neutral atom, doublet multiplicity\n",
+    "# H\n",
+    "# }\n",
+    "\n",
+    "# set reference uhf\n",
+    "\n",
+    "# set basis cc-pvDZ\n",
+    "# energy('hf')\n",
+    "# print_variables()\n",
+    "\n",
+    "# clean()\n",
+    "\n",
+    "# set basis cc-pvtz\n",
+    "# energy('hf')\n",
+    "# print_variables()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# eLO = -0.499278403420\n",
+    "# eHI = -0.499809811302\n",
+    "# do math\n",
+    "eCBS ="
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "### Method 2: by python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "psi4.core.clean_variables()\n",
+    "psi4.core.clean_options()\n",
+    "psi4.core.clean()\n",
+    "\n",
+    "psi4.set_options({'reference': 'uhf',\n",
+    "                  'basis': 'cc-pvdz'})\n",
+    "\n",
+    "eLO = psi4.energy('hf')\n",
+    "\n",
+    "print('eLO =', eLO)\n",
+    "\n",
+    "psi4.core.clean_variables()\n",
+    "psi4.core.clean_options()\n",
+    "psi4.core.clean()\n",
+    "\n",
+    "psi4.set_options({'reference': 'uhf',\n",
+    "                  'basis': 'cc-pvtz'})\n",
+    "\n",
+    "eHI = psi4.energy('hf')\n",
+    "\n",
+    "print('eHI =', eHI)\n",
+    "\n",
+    "\n",
+    "# jobs over. now post-processing\n",
+    "zLO = 2  # cc-pvdz is double-zeta\n",
+    "zHI = 3  # cc-pvtz is triple-zeta\n",
+    "alpha = 1.63\n",
+    "\n",
+    "import math\n",
+    "beta = (eHI - eLO) / (math.exp(-1 * alpha * zLO) * (math.exp(-1 * alpha) - 1))\n",
+    "eCBS = eHI - beta * math.exp(-1 * alpha * zHI)\n",
+    "\n",
+    "print('LO', zLO, eLO)\n",
+    "print('HI', zHI, eHI)\n",
+    "print('CBS', eCBS)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "### Method 3: by Psi4 internal wrapper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "Edtz = psi4.energy('hf/cc-pv[dt]z')\n",
+    "\n",
+    "print('Edtz =', Edtz)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "**Q.** How do the results compare between your hand-computed and Psi4-computed figures?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "## B. Optimization & Frequency Application: rotational barriers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "### 1. Potential Energy Curve\n",
+    "\n",
+    "**Q.** Take an ethane molecule and trace its potential energy as a function of rotation up to 120$^\\circ$ around the C–C single bond. Why choose 120$^\\circ$? Would more or less yield more information?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import collections\n",
+    "answers = collections.OrderedDict()\n",
+    "\n",
+    "\n",
+    "psi4.core.clean_variables()\n",
+    "psi4.core.clean_options()\n",
+    "psi4.core.clean()\n",
+    "\n",
+    "# %%writefile pec.in\n",
+    "\n",
+    "eth = psi4.geometry(\"\"\"\n",
+    "C\n",
+    "C  1  r2\n",
+    "H  1  r3  2  a3\n",
+    "H  1  r4  2  a4  3  d4\n",
+    "H  1  r5  2  a5  3  d5\n",
+    "\n",
+    "H  2  r6  1  a6  3  d6\n",
+    "H  2  r7  1  a7  3  d7\n",
+    "H  2  r8  1  a8  3  d8\n",
+    "\n",
+    "r2= 1.5193\n",
+    "r3= 1.1103\n",
+    "a3= 109.82\n",
+    "r4= 1.1103\n",
+    "a4= 109.82\n",
+    "d4= 240.00\n",
+    "r5= 1.1103\n",
+    "a5= 109.82\n",
+    "d5= 120.00\n",
+    "r6= 1.1103\n",
+    "a6= 109.82\n",
+    "d6=  60.00\n",
+    "r7= 1.1103\n",
+    "a7= 109.82\n",
+    "d7= 300.00\n",
+    "r8= 1.1103\n",
+    "a8= 109.82\n",
+    "d8= 179.97\n",
+    "\"\"\")\n",
+    "\n",
+    "\n",
+    "psi4.set_options({'basis': '3-21g'})\n",
+    "\n",
+    "# one full cycle in 15 deg increments\n",
+    "for dih in range(0, 121, 15):\n",
+    "    eth.d6 =  60.0 + dih\n",
+    "    eth.d7 = 300.0 + dih\n",
+    "    eth.d8 = 180.0 + dih\n",
+    "    \n",
+    "    e = psi4.energy('b3lyp')\n",
+    "    answers[dih] = e\n",
+    "    print(\"\"\"{:10} {:16.8f}\"\"\".format(dih, e))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# # cc-pvdz\n",
+    "# answers = {\n",
+    "# 0: -79.8282248783,\n",
+    "# 15: -79.8273852372,\n",
+    "# 30: -79.82534081,\n",
+    "# 45: -79.8232732704,\n",
+    "# 60: -79.822412629,\n",
+    "# 75: -79.8232732704,\n",
+    "# 90: -79.82534081,\n",
+    "# 105: -79.8273852372,\n",
+    "# 120: -79.8282262361,\n",
+    "#     }\n",
+    "# # 3-21g\n",
+    "# answers = {\n",
+    "# 0: -79.4015689083,\n",
+    "# 15: -79.4007537622,\n",
+    "# 30: -79.3987687086,\n",
+    "# 45: -79.3967648645,\n",
+    "# 60: -79.3959327201,\n",
+    "# 75: -79.3967648645, \n",
+    "# 90: -79.3987687086,\n",
+    "# 105: -79.4007537622,\n",
+    "# 120: -79.4015714988,\n",
+    "# }\n",
+    "# for ang, ene in answers.iteritems():\n",
+    "#     print \"\"\"{:10} {:16.8f}\"\"\".format(ang, ene)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(list(answers.keys()), list(answers.values()), 'ro')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(list(answers.keys()), [(ans - answers[0]) * 627.5095 for ans in answers.values()], 'bo')\n",
+    "plt.axis([-5, 125, -0.1, 4.0])\n",
+    "plt.xlabel('torsion angle [deg]')\n",
+    "plt.ylabel('potential energy [kcal/mol]')\n",
+    "plt.title('ethane torsion')\n",
+    "plt.annotate(r'staggered', xy=(0, 0))\n",
+    "plt.annotate('eclipsed', xy=(60, 3.5))\n",
+    "plt.annotate(r'staggered', xy=(120, 0))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "### 2. Optimized curve\n",
+    "\n",
+    "The above was a MM-optimized staggered minimum, then a rigid rotation around the C–C single bond. Now try optimizing the endpoints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# %%writefile staggered_opt.in\n",
+    "# molecule eth {\n",
+    "# C\n",
+    "# C  1  r2\n",
+    "# H  1  r3  2  a3\n",
+    "# H  1  r4  2  a4  3  d4\n",
+    "# H  1  r5  2  a5  3  d5\n",
+    "\n",
+    "# H  2  r6  1  a6  3  d6\n",
+    "# H  2  r7  1  a7  3  d7\n",
+    "# H  2  r8  1  a8  3  d8\n",
+    "\n",
+    "# r2= 1.5193\n",
+    "# r3= 1.1103\n",
+    "# a3= 109.82\n",
+    "# r4= 1.1103\n",
+    "# a4= 109.82\n",
+    "# d4= 240.00\n",
+    "# r5= 1.1103\n",
+    "# a5= 109.82\n",
+    "# d5= 120.00\n",
+    "# r6= 1.1103\n",
+    "# a6= 109.82\n",
+    "# d6=  60.00\n",
+    "# r7= 1.1103\n",
+    "# a7= 109.82\n",
+    "# d7= 300.00\n",
+    "# r8= 1.1103\n",
+    "# a8= 109.82\n",
+    "# d8= 179.97\n",
+    "# }\n",
+    "\n",
+    "# set basis 3-21g\n",
+    "\n",
+    "e_staggered = psi4.optimize('b3lyp')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!grep '~' cbs_1.out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!tail -100 cbs_1.out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# %%writefile eclipsed_opt.in\n",
+    "# molecule eth {\n",
+    "# C\n",
+    "# C  1  r2\n",
+    "# H  1  r3  2  a3\n",
+    "# H  1  r4  2  a4  3  d4\n",
+    "# H  1  r5  2  a5  3  d5\n",
+    "\n",
+    "# H  2  r6  1  a6  3  d6\n",
+    "# H  2  r7  1  a7  3  d7\n",
+    "# H  2  r8  1  a8  3  d8\n",
+    "\n",
+    "# r2= 1.5193\n",
+    "# r3= 1.1103\n",
+    "# a3= 109.82\n",
+    "# r4= 1.1103\n",
+    "# a4= 109.82\n",
+    "# d4= 240.00\n",
+    "# r5= 1.1103\n",
+    "# a5= 109.82\n",
+    "# d5= 120.00\n",
+    "# r6= 1.1103\n",
+    "# a6= 109.82\n",
+    "# d6=  60.00\n",
+    "# r7= 1.1103\n",
+    "# a7= 109.82\n",
+    "# d7= 300.00\n",
+    "# r8= 1.1103\n",
+    "# a8= 109.82\n",
+    "# d8= 179.97\n",
+    "# }\n",
+    "\n",
+    "# set basis 3-21g\n",
+    "\n",
+    "# eth.d6 = 120.0\n",
+    "# eth.d7 = 360.0\n",
+    "# eth.d8 = 240.0\n",
+    "\n",
+    "# set opt_type ts\n",
+    "\n",
+    "\n",
+    "eth = psi4.geometry(\"\"\"\n",
+    "C\n",
+    "C  1  r2\n",
+    "H  1  r3  2  a3\n",
+    "H  1  r4  2  a4  3  d4\n",
+    "H  1  r5  2  a5  3  d5\n",
+    "\n",
+    "H  2  r6  1  a6  3  d6\n",
+    "H  2  r7  1  a7  3  d7\n",
+    "H  2  r8  1  a8  3  d8\n",
+    "\n",
+    "r2= 1.5193\n",
+    "r3= 1.1103\n",
+    "a3= 109.82\n",
+    "r4= 1.1103\n",
+    "a4= 109.82\n",
+    "d4= 240.00\n",
+    "r5= 1.1103\n",
+    "a5= 109.82\n",
+    "d5= 120.00\n",
+    "r6= 1.1103\n",
+    "a6= 109.82\n",
+    "d6=  60.00\n",
+    "r7= 1.1103\n",
+    "a7= 109.82\n",
+    "d7= 300.00\n",
+    "r8= 1.1103\n",
+    "a8= 109.82\n",
+    "d8= 179.97\n",
+    "\"\"\")\n",
+    "\n",
+    "eth.d6 = 120.0\n",
+    "eth.d7 = 360.0\n",
+    "eth.d8 = 240.0\n",
+    "\n",
+    "psi4.set_options({'basis': '3-21g',\n",
+    "                  'opt_type': 'ts'})\n",
+    "\n",
+    "e_eclipsed = psi4.optimize('b3lyp')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# ! psi4 eclipsed_opt.in"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    },
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "! grep '~' cbs_1.out\n",
+    "! tail -100 cbs_1.out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "### 3. Thermodynamic corrections\n",
+    "\n",
+    "**Q.** What effect on the rotational barrier does vibrational energy have? internal energy? enthalpy? free energy? doubling the temperature?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#%%writefile freqs.in\n",
+    "stag = psi4.geometry(\"\"\"\n",
+    "    C       \n",
+    "    C             1          r2\n",
+    "    H             1          r3      2          a3\n",
+    "    H             1          r4      2          a4      3          d4\n",
+    "    H             1          r5      2          a5      3          d5\n",
+    "    H             2          r6      1          a6      3          d6\n",
+    "    H             2          r7      1          a7      3          d7\n",
+    "    H             2          r8      1          a8      3          d8\n",
+    "\n",
+    "    a3        =  110.9135020855\n",
+    "    a4        =  110.9118973107\n",
+    "    a5        =  110.9132048683\n",
+    "    a6        =  110.9130880760\n",
+    "    a7        =  110.9120167265\n",
+    "    a8        =  110.9134968558\n",
+    "    d4        = -119.9997985457\n",
+    "    d5        =  120.0009727632\n",
+    "    d6        =   59.9988300896\n",
+    "    d7        =  -60.0004071780\n",
+    "    d8        =  179.9988111527\n",
+    "    r2        =    1.5432372377\n",
+    "    r3        =    1.0955417759\n",
+    "    r4        =    1.0955431815\n",
+    "    r5        =    1.0955432326\n",
+    "    r6        =    1.0955475452\n",
+    "    r7        =    1.0955388617\n",
+    "    r8        =    1.0955417809\n",
+    "\"\"\")\n",
+    "\n",
+    "eclip = psi4.geometry(\"\"\"\n",
+    "    C       \n",
+    "    C             1          r2\n",
+    "    H             1          r3      2          a3\n",
+    "    H             1          r4      2          a4      3          d4\n",
+    "    H             1          r5      2          a5      3          d5\n",
+    "    H             2          r6      1          a6      3          d6\n",
+    "    H             2          r7      1          a7      3          d7\n",
+    "    H             2          r8      1          a8      3          d8\n",
+    "\n",
+    "    a3        =  111.2755161893\n",
+    "    a4        =  111.2755161893\n",
+    "    a5        =  111.2753191064\n",
+    "    a6        =  111.2755161893\n",
+    "    a7        =  111.2755161893\n",
+    "    a8        =  111.2753191064\n",
+    "    d4        = -120.0000441842\n",
+    "    d5        =  119.9999779079\n",
+    "    d6        =  120.0000441842\n",
+    "    d7        =    0.0000000000\n",
+    "    d8        = -119.9999779079\n",
+    "    r2        =    1.5587040608\n",
+    "    r3        =    1.0945195926\n",
+    "    r4        =    1.0945195926\n",
+    "    r5        =    1.0945202683\n",
+    "    r6        =    1.0945195926\n",
+    "    r7        =    1.0945195926\n",
+    "    r8        =    1.0945202683\n",
+    "\"\"\")\n",
+    "\n",
+    "psi4.set_options({'basis': '3-21g'})\n",
+    "\n",
+    "e, wfn = psi4.freq('b3lyp', molecule=stag, return_wfn=True)\n",
+    "psi4.core.clean()\n",
+    "\n",
+    "psi4.set_options({'t': 400.0})\n",
+    "psi4.core.thermo(wfn, wfn.frequencies())\n",
+    "psi4.core.clean()\n",
+    "\n",
+    "psi4.set_options({'t': 298.15})\n",
+    "e, wfn = psi4.freq('b3lyp', molecule=eclip, return_wfn=True)\n",
+    "psi4.core.clean()\n",
+    "\n",
+    "psi4.set_options({'t': 400.0})\n",
+    "psi4.core.thermo(wfn, wfn.frequencies())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#!tail -1000 freqs.out\n",
+    "!tail -1000 cbs_1.out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "! grep '\\[K\\]' cbs_1.out | grep '[Eh]' | awk '{print $(NF-1)}'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "E0, = plt.plot([0, 60], [0, 627.5095 * (-79.39888418 - -79.40320254)], 'k--v', label='Electronic energy at well bottom at 0 [K]')\n",
+    "ZPE, = plt.plot([0, 60], [0, 627.5095 * (-79.32340729 - -79.32733679)], 'k--o', label='Electronic energy at 0 [K]')\n",
+    "E, = plt.plot([0, 60], [0, 627.5095 * (-79.32038186 - -79.32387449)], 'b--o', label='Electronic energy at  298.15 [K]')\n",
+    "H, = plt.plot([0, 60], [0, 627.5095 * (-79.31943767 - -79.32293031)], 'g--o', label='Enthalpy at  298.15 [K]')\n",
+    "G, = plt.plot([0, 60], [0, 627.5095 * (-79.34564088 - -79.35046391)], 'r--o', label='Free enthalpy at  298.15 [K]')\n",
+    "E400, = plt.plot([0, 60], [0, 627.5095 * (-79.31885241 - -79.32203961)], 'c-.s', label='Electronic energy at 400.00 [K]')\n",
+    "H400, = plt.plot([0, 60], [0, 627.5095 * (-79.31758568 - -79.32077288)], 'y-.s', label='Enthalpy at 400.00 [K]')\n",
+    "G400, = plt.plot([0, 60], [0, 627.5095 * (-79.35486460 - -79.36018859)], 'm-.s', label='Free enthalpy at 400.00 [K]')\n",
+    "MM, = plt.plot(answers.keys(), [(ans - answers[0]) * 627.5095 for ans in answers.values()], 'kv', label='Elec energy unrelaxed')\n",
+    "plt.legend(handles=[E0, ZPE, E, H, G, MM, E400, H400, G400], bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "## C. Fragmentation Application: energy decomposition\n",
+    "\n",
+    "adapted from tutorial by C. David Sherrill, Georgia Tech at http://psicode.org/psi4manual/master/tutorial.html#analysis-of-intermolecular-interactions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "We can analyze the nature of intermolecular interactions between two molecules, via symmetry-adapted perturbation theory (SAPT) [Jeziorski:1994:1887]. This kind of analysis gives a lot of insight into the nature of intermolecular interactions, and Psi4 makes these computations easier than ever.\n",
+    "\n",
+    "For a SAPT computation, the input needs to provide information on two distinct molecules. This is very easy, we just give a Z-matrix or set of Cartesian coordinates for each molecule, and separate the two with two dashes, like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#%%writefile sapt.in\n",
+    "# Example SAPT computation for ethene*ethine (i.e., ethylene*acetylene),\n",
+    "# test case 16 from the S22 database\n",
+    "\n",
+    "\n",
+    "psi4.core.clean_variables()\n",
+    "psi4.core.clean_options()\n",
+    "psi4.core.clean()\n",
+    "\n",
+    "psi4.set_output_file(\"sapt.out\", True)\n",
+    "\n",
+    "dimer = psi4.geometry(\"\"\"\n",
+    "0 1\n",
+    "C   0.000000  -0.667578  -2.124659\n",
+    "C   0.000000   0.667578  -2.124659\n",
+    "H   0.923621  -1.232253  -2.126185\n",
+    "H  -0.923621  -1.232253  -2.126185\n",
+    "H  -0.923621   1.232253  -2.126185\n",
+    "H   0.923621   1.232253  -2.126185\n",
+    "--\n",
+    "0 1\n",
+    "C   0.000000   0.000000   2.900503\n",
+    "C   0.000000   0.000000   1.693240\n",
+    "H   0.000000   0.000000   0.627352\n",
+    "H   0.000000   0.000000   3.963929\n",
+    "units angstrom\n",
+    "\"\"\")\n",
+    "\n",
+    "psi4.set_options({'basis': 'jun-cc-pvdz', 'freeze_core': 'True'})\n",
+    "\n",
+    "psi4.energy('sapt0')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "To speed up the computation a little, we also tell the SAPT procedure to freeze the core electrons with freeze_core True. The SAPT procedure is invoked with the simple call, energy('sapt0'). This call knows to automatically run two monomer computations and a dimer computation and then use these results to perform the SAPT analysis. The various energy components are printed at the end of the output, in addition to the total SAPT0 interaction energy. An explanation of the various energy components can be found in the review by Jeziorski, Moszynski, and Szalewicz [Jeziorski:1994:1887], and this is discussed in more detail in the SAPT section later in this manual. For now, we’ll note that most of the SAPT energy components are negative; this means those are attractive contributions (the zero of energy in a SAPT computation is defined as non-interacting monomers). The exchange contributions are positive (repulsive). In this example, the most attractive contribution between ethylene and acetylene is an electrostatic term of -2.12 kcal/mol (Elst10,r where the 1 indicates the first-order perturbation theory result with respect to the intermolecular interaction, and the 0 indicates zeroth-order with respect to intramolecular electron correlation). The next most attractive contribution is the Disp20 term (2nd order intermolecular dispersion, which looks like an MP2 in which one excitation is placed on each monomer), contributing an attraction of -1.21 kcal/mol. It is not surprising that the electrostatic contribution is dominant, because the geometry chosen for this example has the acetylene perpendicular to the ethylene, with the acetylene hydrogen pointing directly at the double bond in ethylene; this will be attractive because the H atoms in acetylene bear a partial positive charge, while the electron-rich double bond in ethylene bears a partial negative charge. At the same time, the dispersion interaction should be smaller because the perpendicular geometry does not allow much overlap between the monomers. Hence, the SAPT analysis helps clarify (and quantify) our physical understanding about the interaction between the two monomers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# # tern.py is in the github repo/tarball so adjust path accordingly\n",
+    "# import sys\n",
+    "# sys.path.append('/Users/loriab/linux/psi4workshop')\n",
+    "# import tern"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Module with matplotlib plotting routines. These are not hooked up to\n",
+    "any particular qcdb data structures but can be called with basic\n",
+    "arguments.\n",
+    "\n",
+    "\"\"\"\n",
+    "from __future__ import absolute_import\n",
+    "from __future__ import print_function\n",
+    "import os\n",
+    "\n",
+    "def ternary(sapt, title='', labeled=True, view=True,\n",
+    "            saveas=None, relpath=False, graphicsformat=['pdf']):\n",
+    "    \"\"\"Takes array of arrays *sapt* in form [elst, indc, disp] and builds formatted\n",
+    "    two-triangle ternary diagrams. Either fully-readable or dotsonly depending\n",
+    "    on *labeled*. Saves in formats *graphicsformat*.\n",
+    "\n",
+    "    \"\"\"\n",
+    "    import hashlib\n",
+    "    import numpy as np\n",
+    "    import matplotlib.pyplot as plt\n",
+    "    import matplotlib as mpl\n",
+    "    from matplotlib.path import Path\n",
+    "    import matplotlib.patches as patches\n",
+    "\n",
+    "    # initialize plot\n",
+    "    fig, ax = plt.subplots(figsize=(6, 3.6))\n",
+    "    plt.xlim([-0.75, 1.25])\n",
+    "    plt.ylim([-0.18, 1.02])\n",
+    "    plt.xticks([])\n",
+    "    plt.yticks([])\n",
+    "    ax.set_aspect('equal')\n",
+    "\n",
+    "    if labeled:\n",
+    "        # form and color ternary triangles\n",
+    "        codes = [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY]\n",
+    "        pathPos = Path([(0., 0.), (1., 0.), (0.5, 0.866), (0., 0.)], codes)\n",
+    "        pathNeg = Path([(0., 0.), (-0.5, 0.866), (0.5, 0.866), (0., 0.)], codes)\n",
+    "        ax.add_patch(patches.PathPatch(pathPos, facecolor='white', lw=2))\n",
+    "        ax.add_patch(patches.PathPatch(pathNeg, facecolor='#fff5ee', lw=2))\n",
+    "\n",
+    "        # form and color HB/MX/DD dividing lines\n",
+    "        ax.plot([0.667, 0.5], [0., 0.866], color='#eeb4b4', lw=0.5)\n",
+    "        ax.plot([-0.333, 0.5], [0.577, 0.866], color='#eeb4b4', lw=0.5)\n",
+    "        ax.plot([0.333, 0.5], [0., 0.866], color='#7ec0ee', lw=0.5)\n",
+    "        ax.plot([-0.167, 0.5], [0.289, 0.866], color='#7ec0ee', lw=0.5)\n",
+    "\n",
+    "        # label corners\n",
+    "        ax.text(1.0, -0.15, u'Elst (\\u2212)',\n",
+    "            verticalalignment='bottom', horizontalalignment='center',\n",
+    "            family='Times New Roman', weight='bold', fontsize=18)\n",
+    "        ax.text(0.5, 0.9, u'Ind (\\u2212)',\n",
+    "            verticalalignment='bottom', horizontalalignment='center',\n",
+    "            family='Times New Roman', weight='bold', fontsize=18)\n",
+    "        ax.text(0.0, -0.15, u'Disp (\\u2212)',\n",
+    "            verticalalignment='bottom', horizontalalignment='center',\n",
+    "            family='Times New Roman', weight='bold', fontsize=18)\n",
+    "        ax.text(-0.5, 0.9, u'Elst (+)',\n",
+    "            verticalalignment='bottom', horizontalalignment='center',\n",
+    "            family='Times New Roman', weight='bold', fontsize=18)\n",
+    "\n",
+    "    xvals = []\n",
+    "    yvals = []\n",
+    "    cvals = []\n",
+    "    for sys in sapt:\n",
+    "        [elst, indc, disp] = sys\n",
+    "\n",
+    "        # calc ternary posn and color\n",
+    "        Ftop = abs(indc) / (abs(elst) + abs(indc) + abs(disp))\n",
+    "        Fright = abs(elst) / (abs(elst) + abs(indc) + abs(disp))\n",
+    "        xdot = 0.5 * Ftop + Fright\n",
+    "        ydot = 0.866 * Ftop\n",
+    "        cdot = 0.5 + (xdot - 0.5) / (1. - Ftop)\n",
+    "        if elst > 0.:\n",
+    "            xdot = 0.5 * (Ftop - Fright)\n",
+    "            ydot = 0.866 * (Ftop + Fright)\n",
+    "        #print elst, indc, disp, '', xdot, ydot, cdot\n",
+    "\n",
+    "        xvals.append(xdot)\n",
+    "        yvals.append(ydot)\n",
+    "        cvals.append(cdot)\n",
+    "\n",
+    "    sc = ax.scatter(xvals, yvals, c=cvals, s=25, marker=\"o\", \\\n",
+    "        cmap=mpl.cm.jet, edgecolor='none', vmin=0, vmax=1, zorder=10)\n",
+    "\n",
+    "    # remove figure outline\n",
+    "    ax.spines['top'].set_visible(False)\n",
+    "    ax.spines['right'].set_visible(False)\n",
+    "    ax.spines['bottom'].set_visible(False)\n",
+    "    ax.spines['left'].set_visible(False)\n",
+    "\n",
+    "    # save and show\n",
+    "    pltuid = title + '_' + ('lbld' if labeled else 'bare') #+ '_' + hashlib.sha1(title + repr(sapt)).hexdigest()\n",
+    "    pltfile = 'tern_'\n",
+    "    files_saved = {}\n",
+    "    for ext in graphicsformat:\n",
+    "        savefile = pltfile + '.' + ext.lower()\n",
+    "        plt.savefig(savefile, transparent=True, format=ext, bbox_inches='tight',\n",
+    "                    frameon=False, dpi=450, edgecolor='none', pad_inches=0.0)\n",
+    "        files_saved[ext.lower()] = savefile\n",
+    "    if view:\n",
+    "        plt.show()\n",
+    "    plt.close()\n",
+    "    return files_saved\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ternary([[-2.11997068, -0.55805356, -1.04937892]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "**Q.** Now try a methane dimer. Where does it appear? Can you find more complexes to fill in other regions of the graph? (Think charged systems, $\\pi$/$\\pi$ contacts, hydrogen bonds, repulsive complexes.) Some geometries to try here: https://raw.githubusercontent.com/psi4/psi4/master/share/databases/A24.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#%%writefile sapt2.in\n",
+    "import psi4\n",
+    "\n",
+    "psi4.core.clean_variables()\n",
+    "psi4.core.clean_options()\n",
+    "psi4.core.clean()\n",
+    "\n",
+    "psi4.set_output_file(\"sapt2.out\", True)\n",
+    "\n",
+    "psi4.geometry(\"\"\"\n",
+    "0 1\n",
+    "C   0.000000  -0.000140   1.859161\n",
+    "H  -0.888551   0.513060   1.494685\n",
+    "H   0.888551   0.513060   1.494685\n",
+    "H   0.000000  -1.026339   1.494868\n",
+    "H   0.000000   0.000089   2.948284\n",
+    "--\n",
+    "0 1\n",
+    "C   0.000000   0.000140  -1.859161\n",
+    "H   0.000000  -0.000089  -2.948284\n",
+    "H  -0.888551  -0.513060  -1.494685\n",
+    "H   0.888551  -0.513060  -1.494685\n",
+    "H   0.000000   1.026339  -1.494868\n",
+    "\"\"\")\n",
+    "\n",
+    "psi4.set_options({'basis': 'jun-cc-pvdz', 'freeze_core': 'True'})\n",
+    "\n",
+    "psi4.energy('sapt0')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ternary([[-2.11997068, -0.55805356, -1.04937892],\n",
+    "              [-0.13986987, -0.03988538, -0.53624514]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
Here's an intro lab. Not very colorful, but it contains a few mpl plots. The imports at the top are very ragged, I'm afraid, because I was checking it against a dev-compiled psi4. Proper thing to do is install the conda pkg `conda install psi4 matplotlib -c psi4/label/dev -c psi4`. Then, with a normal setup, `bin/psi4 --version` or `python -c "import psi4; print(psi4.__version__)"` work. If additional tampering required, the needed paths are printed via `bin/psi4 --psiapi-path` and should be executed before the jupyter env is launched (may be very different in Hub env, of course). Originally written for 2.7 and just checked against 3.6.